### PR TITLE
Update flightdata.py

### DIFF
--- a/flightdata.py
+++ b/flightdata.py
@@ -201,6 +201,8 @@ class Dump1090DataParser(AircraftDataParser):
             speed = 0
             if "speed" in a:
                 speed = geomath.knot2mph(a["speed"])
+            if "gs" in a:
+                speed = geomath.knot2mph(a["gs"])
             if "mach" in a:
                 speed = geomath.mach2mph(a["mach"])
 


### PR DESCRIPTION
Added two lines at 204 and 205. I built on dump1090-fa and not piaware. I wasn't getting the aircraft's speed to show up in my tweets. OverPutney looks for "speed" in the aircraft.json file, which must be how piaware displays it. 

dump1090-fa uses "gs" (ground speed) instead of "speed". By adding this, both piaware and dump1090-fa users should be able to have the aircraft's speed displayed in the tweets created by OverPutney.